### PR TITLE
Remove daemon off command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
 FROM nginx
 ADD nginx.conf /etc/nginx/nginx.conf
-
-# Append "daemon off;" to the beginning of the configuration
-RUN echo "daemon off;" >> /etc/nginx/nginx.conf
-
 RUN mkdir assets


### PR DESCRIPTION
The base nginx image was updated to add daemon off by default, so adding this line to the configuration causes a confusing `"daemon" directive is duplicate` error. See [this pull request](https://github.com/dockerfile/nginx/pull/10)
